### PR TITLE
add force=yes to avoid apt task crash

### DIFF
--- a/provisioning/roles/sonarr/tasks/main.yml
+++ b/provisioning/roles/sonarr/tasks/main.yml
@@ -2,7 +2,7 @@
 - apt_repository: repo='deb http://apt.sonarr.tv/ master main' state=present
   sudo: yes
 
-- apt: name=nzbdrone update_cache=yes
+- apt: name=nzbdrone update_cache=yes force=yes
   sudo: yes
 
 - copy: src=init_d dest=/etc/init.d/nzbdrone mode=0744


### PR DESCRIPTION
playbook run crash on task sonarr apt name=nzbdrone
https://gist.github.com/j-carpentier/4d6ecf313b19e367d6c8
workaround consist of using force=yes for apt module
