### PR TITLE
hack for package auth, allow_unauthenticated only in ansible v2.1

### DIFF
--- a/provisioning/roles/sonarr/tasks/main.yml
+++ b/provisioning/roles/sonarr/tasks/main.yml
@@ -2,6 +2,9 @@
 - apt_repository: repo='deb http://apt.sonarr.tv/ master main' state=present
   sudo: yes
 
+- name: super-ugly hack to allow unauthenticated packages to install
+  copy: content='APT::Get::AllowUnauthenticated "true";' dest=/etc/apt/apt.conf.d/99temp owner=root group=root mode=0644
+
 - apt: name=nzbdrone update_cache=yes
   sudo: yes
 


### PR DESCRIPTION
Hack for ansible v2.0

allow_unauthenticated only available in ansible v2.1 for the moment
https://github.com/ansible/ansible/issues/11620
